### PR TITLE
Add Reverse Futility Pruning / Static Null Move Pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -410,6 +410,17 @@ int Negamax(int alpha, int beta, int depth, ThreadData* td, SearchStack* ss) {
         StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, ss->staticEval, HFNONE, 0, pvNode, ttPv);
     }
 
+    if (   !pvNode
+        && !inCheck) {
+        // Reverse Futility Pruning (RFP) / Static Null Move Pruning (SNMP)
+        // At low depths, if the evaluation is far above beta, we assume that at least one move will fail high
+        // and return a fail high score.
+        if (   depth <= 8
+            && eval - 70 * depth >= beta
+            && std::abs(eval) < MATE_FOUND)
+            return eval;
+    }
+
     // old value of alpha
     const int old_alpha = alpha;
     int bestScore = -MAXSCORE;


### PR DESCRIPTION
Elo   | 183.83 +- 34.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.97 (-2.25, 2.89) [0.00, 10.00]
Games | N: 392 W: 253 L: 63 D: 76
Penta | [3, 11, 54, 49, 79]