### PR TITLE
Introduce an additional dimension in quiet history based on whether the from-square is threatened

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -11,13 +11,16 @@ int16_t HistoryBonus(const int depth) {
 
 // Quiet history is a history table indexed by the side-to-move as well as a quiet move's [from-to].
 void UpdateQuietHistory(const Position *pos, SearchData *sd, const Move move, const int16_t bonus) {
+
+    int16_t &entry = sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][FromTo(move)];
+
     // Scale the bonus so that the history, when updated, will be within [-quietHistMax(), quietHistMax()]
-    const int scaledBonus = bonus - sd->quietHistory[pos->side][FromTo(move)] * std::abs(bonus) / quietHistMax();
-    sd->quietHistory[pos->side][FromTo(move)] += bonus;
+    const int scaledBonus = bonus - entry * std::abs(bonus) / quietHistMax();
+    entry += bonus;
 }
 
 int16_t GetQuietHistoryScore(const Position *pos, const SearchData *sd, const Move move) {
-    return sd->quietHistory[pos->side][FromTo(move)];
+    return sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][FromTo(move)];
 }
 
 // Use this function to update all quiet histories

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -9,7 +9,7 @@ int16_t HistoryBonus(const int depth) {
     return std::min(histBonusQuadratic() * depth * depth + histBonusLinear() * depth + histBonusConst(), histBonusMax());
 }
 
-// Quiet history is a history table indexed by the side-to-move as well as a quiet move's [from-to].
+// Quiet history is a history table indexed by [side-to-move][from-sq-is-attacked][from-to-of-move].
 void UpdateQuietHistory(const Position *pos, SearchData *sd, const Move move, const int16_t bonus) {
 
     int16_t &entry = sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][FromTo(move)];

--- a/src/history.h
+++ b/src/history.h
@@ -9,7 +9,7 @@ struct MoveList;
 
 int16_t HistoryBonus(const int depth);
 
-// Quiet history is a history table indexed by the side-to-move as well as a quiet move's [from-to].
+// Quiet history is a history table indexed by [side-to-move][from-sq-is-attacked][from-to-of-move].
 void UpdateQuietHistory(const Position *pos, SearchData *sd, const Move move, const int16_t bonus);
 int16_t GetQuietHistoryScore(const Position *pos, const SearchData *sd, const Move move);
 

--- a/src/makemove.cpp
+++ b/src/makemove.cpp
@@ -326,6 +326,10 @@ void MakeMove(const Move move, Position* pos) {
     }
     else
         pos->checkMask = fullCheckmask;
+
+    // Update opponent threats
+    pos->oppThreats = getThreats(pos, pos->side ^ 1);
+
     // Make sure a freshly generated zobrist key matches the one we are incrementally updating
     assert(pos->posKey == GeneratePosKey(pos));
     assert(pos->pawnKey == GeneratePawnKey(pos));

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -221,6 +221,9 @@ void ParseFen(const std::string& command, Position* pos) {
     else
         pos->checkMask = fullCheckmask;
 
+    // Update opponent threats
+    pos->oppThreats = getThreats(pos, pos->side ^ 1);
+
     // Update nnue accumulator to reflect board state
     nnue.accumulate(pos->accumStack[0], pos);
     pos->accumStackHead = 1;
@@ -396,6 +399,11 @@ Bitboard getThreats(const Position* pos, const int side) {
     return threats;
 }
 
+bool IsAttackedByOpp(const Position *pos, const int square) {
+    assert(square >= 0 && square <= 63);
+    return pos->oppThreats & (1ULL << square);
+}
+
 // Return a piece based on the piecetype and the color
 int GetPiece(const int piecetype, const int color) {
     return piecetype + 6 * color;
@@ -472,6 +480,7 @@ void saveBoardState(Position* pos) {
     pos->history[pos->historyStackHead].checkers = pos->checkers;
     pos->history[pos->historyStackHead].checkMask = pos->checkMask;
     pos->history[pos->historyStackHead].pinned = pos->pinned;
+    pos->history[pos->historyStackHead].oppThreats = pos->oppThreats;
 }
 
 void restorePreviousBoardState(Position* pos)
@@ -483,6 +492,7 @@ void restorePreviousBoardState(Position* pos)
     pos->checkers = pos->history[pos->historyStackHead].checkers;
     pos->checkMask = pos->history[pos->historyStackHead].checkMask;
     pos->pinned = pos->history[pos->historyStackHead].pinned;
+    pos->oppThreats = pos->history[pos->historyStackHead].oppThreats;
 }
 
 bool hasGameCycle(Position* pos, int ply) {

--- a/src/position.h
+++ b/src/position.h
@@ -30,6 +30,7 @@ struct BoardState {
     int plyFromNull = 0;
     Bitboard checkers = 0ULL;
     Bitboard checkMask = fullCheckmask;
+    Bitboard oppThreats;
     Bitboard pinned;
 }; // stores a move and the state of the game before that move is made
 // for rollback purposes
@@ -60,6 +61,7 @@ public:
     Bitboard occupancies[2] = {};
     Bitboard checkers;
     Bitboard checkMask = fullCheckmask;
+    Bitboard oppThreats;
   
     NNUE::Accumulator accumStack[MAXPLY];
     int accumStackHead;
@@ -181,6 +183,9 @@ void ResetInfo(SearchInfo* info);
 
 // Returns the threats bitboard of the pieces of <side> color
 [[nodiscard]] Bitboard getThreats(const Position* pos, const int side);
+
+// Returns if the square is attacked by the opponent
+[[nodiscard]] bool IsAttackedByOpp(const Position *pos, const int square);
 
 // Returns whether the opponent of <side> has a guaranteed SEE > 0
 [[nodiscard]] bool oppCanWinMaterial(const Position* pos, const int side);

--- a/src/search.h
+++ b/src/search.h
@@ -12,7 +12,7 @@ struct SearchStack {
 };
 
 struct SearchData {
-    int16_t quietHistory[2][64 * 64];
+    int16_t quietHistory[2][2][64 * 64];
 };
 
 struct PvTable {


### PR DESCRIPTION
Elo   | 16.53 +- 8.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3554 W: 1316 L: 1147 D: 1091
Penta | [126, 337, 730, 410, 174]
https://chess.swehosting.se/test/7533/

Bench 4815304