### PR TITLE
Add Late Move Reductions

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -144,6 +144,15 @@ void InitReductions() {
         seeMargins[1][depth] = -double(   quietSeeCoeff()) * std::pow(depth, double(   quietSeePower()) / 100.0) / 100.0; // Quiet SEE margin
 
         futilityMargins[depth] = fpMarginQuadratic() * depth * depth + fpMarginLinear() * depth + fpMarginConst();
+
+        for (int moves = 0; moves < 64; ++moves) {
+            // Manually set reduction to 0 if depth or moves is 0 as log(0) is NaN
+            if (depth == 0 || moves == 0) {
+                lmrReductions[moves][depth] = 0;
+                continue;
+            }
+            lmrReductions[moves][depth] = (double(quietLmrBase()) + double(quietLmrMult()) * std::log(depth) * std::log(moves)) / 1024;
+        }
     }
 }
 

--- a/src/search.h
+++ b/src/search.h
@@ -7,6 +7,7 @@
 
 inline int seeMargins[2][64];
 inline int futilityMargins[64];
+inline int lmrReductions[64][64];
 
 struct SearchStack {
     int ply;

--- a/src/tune.h
+++ b/src/tune.h
@@ -103,3 +103,6 @@ TUNE_PARAM(fpMarginQuadratic, 16, 0, 32, 2, 0.002)
 TUNE_PARAM(fpMarginLinear, 13, 0, 26, 2, 0.002)
 TUNE_PARAM(fpMarginConst, 27, 0, 54, 10, 0.002)
 TUNE_PARAM(fpDepth, 10, 5, 15, 1, 0.002)
+
+TUNE_PARAM(quietLmrBase, 1690, 0, 2535, 128, 0.002)
+TUNE_PARAM(quietLmrMult, 366, 244, 549, 32, 0.002)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -186,7 +186,7 @@ bool ParseGo(const std::string& line, SearchInfo* info, Position* pos) {
 // main UCI loop
 void UciLoop(int argc, char** argv) {
     if (argv[1] && strncmp(argv[1], "bench", 5) == 0) {
-        int benchDepth = 10;
+        int benchDepth = 14;
         // If there's an additional input try to parse it as a bench depth
         if (argc == 3) {
             if (std::stoi(argv[2]) > 0) {


### PR DESCRIPTION
Elo   | 154.14 +- 32.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.25, 2.89) [0.00, 10.00]
Games | N: 240 W: 121 L: 21 D: 98
Penta | [0, 10, 23, 64, 23]
https://chess.swehosting.se/test/7594/

Bench 4132880