### PR TITLE
Add another dimension to quiet history based on threats

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -9,10 +9,10 @@ int16_t HistoryBonus(const int depth) {
     return std::min(histBonusQuadratic() * depth * depth + histBonusLinear() * depth + histBonusConst(), histBonusMax());
 }
 
-// Quiet history is a history table indexed by [side-to-move][from-sq-is-attacked][from-to-of-move].
+// Quiet history is a history table indexed by [side-to-move][from-sq-is-attacked][to-sq-is-attacked][from-to-of-move].
 void UpdateQuietHistory(const Position *pos, SearchData *sd, const Move move, const int16_t bonus) {
 
-    int16_t &entry = sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][FromTo(move)];
+    int16_t &entry = sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][IsAttackedByOpp(pos, To(move))][FromTo(move)];
 
     // Scale the bonus so that the history, when updated, will be within [-quietHistMax(), quietHistMax()]
     const int scaledBonus = bonus - entry * std::abs(bonus) / quietHistMax();
@@ -20,7 +20,7 @@ void UpdateQuietHistory(const Position *pos, SearchData *sd, const Move move, co
 }
 
 int16_t GetQuietHistoryScore(const Position *pos, const SearchData *sd, const Move move) {
-    return sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][FromTo(move)];
+    return sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][IsAttackedByOpp(pos, To(move))][FromTo(move)];
 }
 
 // Use this function to update all quiet histories

--- a/src/search.h
+++ b/src/search.h
@@ -16,7 +16,7 @@ struct SearchStack {
 };
 
 struct SearchData {
-    int16_t quietHistory[2][2][64 * 64];
+    int16_t quietHistory[2][2][2][64 * 64];
 };
 
 struct PvTable {


### PR DESCRIPTION
Elo   | 5.19 +- 3.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10242 W: 2548 L: 2395 D: 5299
Penta | [76, 1172, 2467, 1335, 71]
https://chess.swehosting.se/test/7625/

Bench 4445625