### PR TITLE
Factorise quiet history based on shared from-to of moves

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -9,18 +9,24 @@ int16_t HistoryBonus(const int depth) {
     return std::min(histBonusQuadratic() * depth * depth + histBonusLinear() * depth + histBonusConst(), histBonusMax());
 }
 
-// Quiet history is a history table indexed by [side-to-move][from-sq-is-attacked][to-sq-is-attacked][from-to-of-move].
-void UpdateQuietHistory(const Position *pos, SearchData *sd, const Move move, const int16_t bonus) {
-
-    int16_t &entry = sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][IsAttackedByOpp(pos, To(move))][FromTo(move)];
-
-    // Scale the bonus so that the history, when updated, will be within [-quietHistMax(), quietHistMax()]
-    const int scaledBonus = bonus - entry * std::abs(bonus) / quietHistMax();
+void UpdateHistoryEntry(int16_t &entry, const int16_t bonus, const int16_t max) {
+    const int scaledBonus = bonus - entry * std::abs(bonus) / max;
     entry += scaledBonus;
 }
 
-int16_t GetQuietHistoryScore(const Position *pos, const SearchData *sd, const Move move) {
-    return sd->quietHistory[pos->side][IsAttackedByOpp(pos, From(move))][IsAttackedByOpp(pos, To(move))][FromTo(move)];
+// Quiet history is a history table indexed by [side-to-move][from-to-of-move].
+void QuietHistoryTable::Update(const Position *pos, const Move move, const int16_t bonus) {
+    QuietHistoryEntry &entry = table[pos->side][FromTo(move)];
+    const int factoriserScale = quietHistFactoriserScale();
+    const int bucketScale = 64 - factoriserScale;
+    UpdateHistoryEntry(entry.factoriser, bonus * factoriserScale / 64, quietHistFactoriserMax());
+    UpdateHistoryEntry(entry.bucketRef(pos, move), bonus * bucketScale / 64, quietHistBucketMax());
+}
+
+int16_t QuietHistoryTable::GetScore(const Position *pos, const Move move) const {
+    QuietHistoryEntry entry = table[pos->side][FromTo(move)];
+    return   entry.factoriser
+           + entry.bucket(pos, move);
 }
 
 // Use this function to update all quiet histories
@@ -31,13 +37,13 @@ void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *
     }
     else {
         // Positively update the move that failed high
-        UpdateQuietHistory(pos, sd, bestMove, bonus);
+        sd->quietHistory.Update(pos, bestMove, bonus);
 
         // Penalise all quiets that failed to do so (they were ordered earlier but weren't as good)
         for (int i = 0; i < quietMoves.count; ++i) {
             Move quiet = quietMoves.moves[i].move;
             if (bestMove == quiet) continue;
-            UpdateQuietHistory(pos, sd, quiet, -bonus);
+            sd->quietHistory.Update(pos, quiet, -bonus);
         }
     }
 }
@@ -47,11 +53,11 @@ int GetHistoryScore(const Position *pos, const SearchStack *ss, const SearchData
         return 0;
     }
     else {
-        return GetQuietHistoryScore(pos, sd, move);
+        return sd->quietHistory.GetScore(pos, move);
     }
 }
 
 // Resets the history tables
 void CleanHistories(SearchData *sd) {
-    std::memset(sd->quietHistory, 0, sizeof(sd->quietHistory));
+    sd->quietHistory.clear();
 }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -15,7 +15,7 @@ void UpdateHistoryEntry(int16_t &entry, const int16_t bonus, const int16_t max) 
 }
 
 // Quiet history is a history table indexed by [side-to-move][from-to-of-move].
-void QuietHistoryTable::Update(const Position *pos, const Move move, const int16_t bonus) {
+void QuietHistoryTable::update(const Position *pos, const Move move, const int16_t bonus) {
     QuietHistoryEntry &entry = table[pos->side][FromTo(move)];
     const int factoriserScale = quietHistFactoriserScale();
     const int bucketScale = 64 - factoriserScale;
@@ -23,7 +23,7 @@ void QuietHistoryTable::Update(const Position *pos, const Move move, const int16
     UpdateHistoryEntry(entry.bucketRef(pos, move), bonus * bucketScale / 64, quietHistBucketMax());
 }
 
-int16_t QuietHistoryTable::GetScore(const Position *pos, const Move move) const {
+int16_t QuietHistoryTable::getScore(const Position *pos, const Move move) const {
     QuietHistoryEntry entry = table[pos->side][FromTo(move)];
     return   entry.factoriser
            + entry.bucket(pos, move);
@@ -37,13 +37,13 @@ void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *
     }
     else {
         // Positively update the move that failed high
-        sd->quietHistory.Update(pos, bestMove, bonus);
+        sd->quietHistory.update(pos, bestMove, bonus);
 
         // Penalise all quiets that failed to do so (they were ordered earlier but weren't as good)
         for (int i = 0; i < quietMoves.count; ++i) {
             Move quiet = quietMoves.moves[i].move;
             if (bestMove == quiet) continue;
-            sd->quietHistory.Update(pos, quiet, -bonus);
+            sd->quietHistory.update(pos, quiet, -bonus);
         }
     }
 }
@@ -53,7 +53,7 @@ int GetHistoryScore(const Position *pos, const SearchStack *ss, const SearchData
         return 0;
     }
     else {
-        return sd->quietHistory.GetScore(pos, move);
+        return sd->quietHistory.getScore(pos, move);
     }
 }
 

--- a/src/history.h
+++ b/src/history.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <algorithm>
+#include <cstring>
+#include "position.h"
+#include "move.h"
 #include "types.h"
 
 struct Position;
@@ -8,10 +12,30 @@ struct SearchStack;
 struct MoveList;
 
 int16_t HistoryBonus(const int depth);
+void UpdateHistoryEntry(int16_t &entry, const int16_t bonus, const int16_t max);
 
-// Quiet history is a history table indexed by [side-to-move][from-sq-is-attacked][from-to-of-move].
-void UpdateQuietHistory(const Position *pos, SearchData *sd, const Move move, const int16_t bonus);
-int16_t GetQuietHistoryScore(const Position *pos, const SearchData *sd, const Move move);
+// Quiet history is a history table indexed by [side-to-move][from-to-of-move].
+struct QuietHistoryTable {
+    struct QuietHistoryEntry {
+        int16_t factoriser;
+        int16_t buckets[2][2]; // Buckets indexed by [from-sq-is-attacked][to-sq-is-attacked]
+
+        inline int16_t &bucketRef(const Position *pos, const Move move) {
+            return buckets[IsAttackedByOpp(pos, From(move))][IsAttackedByOpp(pos, To(move))];
+        };
+
+        inline int16_t bucket(const Position *pos, const Move move) const {
+            return buckets[IsAttackedByOpp(pos, From(move))][IsAttackedByOpp(pos, To(move))];
+        };
+    };
+    QuietHistoryEntry table[2][64 * 64];
+
+    void Update(const Position *pos, const Move move, const int16_t bonus);
+    int16_t GetScore(const Position *pos, const Move move) const;
+    inline void clear() {
+        std::memset(table, 0, sizeof(table));
+    };
+};
 
 // Update all histories after a beta cutoff
 void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int depth, const Move bestMove, const MoveList &quietMoves, const MoveList &tacticalMoves);

--- a/src/history.h
+++ b/src/history.h
@@ -30,8 +30,8 @@ struct QuietHistoryTable {
     };
     QuietHistoryEntry table[2][64 * 64];
 
-    void Update(const Position *pos, const Move move, const int16_t bonus);
-    int16_t GetScore(const Position *pos, const Move move) const;
+    void update(const Position *pos, const Move move, const int16_t bonus);
+    int16_t getScore(const Position *pos, const Move move) const;
     inline void clear() {
         std::memset(table, 0, sizeof(table));
     };

--- a/src/search.h
+++ b/src/search.h
@@ -17,7 +17,7 @@ struct SearchStack {
 };
 
 struct SearchData {
-    int16_t quietHistory[2][2][2][64 * 64];
+    QuietHistoryTable quietHistory;
 };
 
 struct PvTable {

--- a/src/tune.h
+++ b/src/tune.h
@@ -109,6 +109,6 @@ TUNE_PARAM(histBonusLinear, 32, 0, 64, 2, 0.002)
 TUNE_PARAM(histBonusConst, 16, 0, 32, 1, 0.002)
 TUNE_PARAM(histBonusMax, 1200, 400, 4800, 100, 0.002)
 
-TUNE_PARAM(quietHistFactoriserScale, 32, 0, 64, 2, 0.002)
-TUNE_PARAM(quietHistFactoriserMax, 6144, 2048, 20000, 300, 0.002)
+TUNE_PARAM(quietHistFactoriserScale, 16, 0, 64, 2, 0.002)
+TUNE_PARAM(quietHistFactoriserMax, 2048, 2048, 20000, 300, 0.002)
 TUNE_PARAM(quietHistBucketMax, 6144, 2048, 20000, 300, 0.002)

--- a/src/tune.h
+++ b/src/tune.h
@@ -109,4 +109,6 @@ TUNE_PARAM(histBonusLinear, 32, 0, 64, 2, 0.002)
 TUNE_PARAM(histBonusConst, 16, 0, 32, 1, 0.002)
 TUNE_PARAM(histBonusMax, 1200, 400, 4800, 100, 0.002)
 
-TUNE_PARAM(quietHistMax, 8192, 4096, 30000, 512, 0.002)
+TUNE_PARAM(quietHistFactoriserScale, 32, 0, 64, 2, 0.002)
+TUNE_PARAM(quietHistFactoriserMax, 6144, 2048, 20000, 300, 0.002)
+TUNE_PARAM(quietHistBucketMax, 6144, 2048, 20000, 300, 0.002)


### PR DESCRIPTION
Elo   | 3.63 +- 2.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17694 W: 4299 L: 4114 D: 9281
Penta | [118, 2157, 4173, 2220, 179]
https://chess.swehosting.se/test/7660/

Bench 3752153