### PR TITLE
Add Continuation History for captures

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -33,11 +33,8 @@ int16_t TacticalHistoryTable::getScore(const Position *pos, const Move move) con
 
 // Continuation history is a history table for move pairs (i.e. a previous move and its continuation)
 void ContinuationHistoryTable::updateSingle(const Position *pos, const SearchStack *ss, const int offset, const Move move, const int16_t bonus) {
-    ContinuationHistoryEntry &entry = getEntryRef((ss - offset)->move, move);
-    const int factoriserScale = continuationHistFactoriserScale();
-    const int bucketScale = 64 - factoriserScale;
-    UpdateHistoryEntry(entry.factoriser, bonus * factoriserScale / 64, continuationHistFactoriserMax());
-    UpdateHistoryEntry(entry.bucketRef((ss - offset)->move, move), bonus * bucketScale / 64, continuationHistBucketMax());
+    ContinuationHistoryEntry &entry = getEntryRef(pos, (ss - offset)->move, move);
+    UpdateHistoryEntry(entry.factoriser, bonus, continuationHistMax());
 }
 
 void ContinuationHistoryTable::update(const Position *pos, const SearchStack *ss, const Move move, const int16_t bonus) {
@@ -46,9 +43,8 @@ void ContinuationHistoryTable::update(const Position *pos, const SearchStack *ss
 }
 
 int16_t ContinuationHistoryTable::getScoreSingle(const Position *pos, const SearchStack *ss, const int offset, const Move move) const {
-    ContinuationHistoryEntry entry = getEntry((ss - offset)->move, move);
-    return   entry.factoriser
-           + entry.bucket((ss - offset)->move, move);
+    ContinuationHistoryEntry entry = getEntry(pos, (ss - offset)->move, move);
+    return entry.factoriser;
 }
 
 int16_t ContinuationHistoryTable::getScore(const Position *pos, const SearchStack *ss, const Move move) const {

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -37,7 +37,7 @@ void ContinuationHistoryTable::updateSingle(const Position *pos, const SearchSta
     const int factoriserScale = continuationHistFactoriserScale();
     const int bucketScale = 64 - factoriserScale;
     UpdateHistoryEntry(entry.factoriser, bonus * factoriserScale / 64, continuationHistFactoriserMax());
-    UpdateHistoryEntry(entry.bucketRef(pos, (ss - offset)->move, move), bonus * bucketScale / 64, continuationHistBucketMax());
+    UpdateHistoryEntry(entry.bucketRef((ss - offset)->move, move), bonus * bucketScale / 64, continuationHistBucketMax());
 }
 
 void ContinuationHistoryTable::update(const Position *pos, const SearchStack *ss, const Move move, const int16_t bonus) {
@@ -48,7 +48,7 @@ void ContinuationHistoryTable::update(const Position *pos, const SearchStack *ss
 int16_t ContinuationHistoryTable::getScoreSingle(const Position *pos, const SearchStack *ss, const int offset, const Move move) const {
     ContinuationHistoryEntry entry = getEntry((ss - offset)->move, move);
     return   entry.factoriser
-           + entry.bucket(pos, (ss - offset)->move, move);
+           + entry.bucket((ss - offset)->move, move);
 }
 
 int16_t ContinuationHistoryTable::getScore(const Position *pos, const SearchStack *ss, const Move move) const {

--- a/src/history.h
+++ b/src/history.h
@@ -66,13 +66,13 @@ struct TacticalHistoryTable {
     TacticalHistoryEntry table[12 * 64][6];
 
     inline TacticalHistoryEntry getEntry(const Position *pos, const Move move) const {
-        int capturedPiece = GetPieceType(pos->PieceOn(To(move)));
+        int capturedPiece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
         if (capturedPiece == EMPTY) capturedPiece = KING; // Impossible to capture kings so we use it as "Empty" slot to save space
         return table[PieceTo(move)][capturedPiece];
     };
 
     inline TacticalHistoryEntry &getEntryRef(const Position *pos, const Move move) {
-        int capturedPiece = GetPieceType(pos->PieceOn(To(move)));
+        int capturedPiece = isEnpassant(move) ? PAWN : GetPieceType(pos->PieceOn(To(move)));
         if (capturedPiece == EMPTY) capturedPiece = KING; // Impossible to capture kings so we use it as "Empty" slot to save space
         return table[PieceTo(move)][capturedPiece];
     };
@@ -89,16 +89,29 @@ struct TacticalHistoryTable {
 struct ContinuationHistoryTable {
     struct ContinuationHistoryEntry {
         int16_t factoriser;
+        int16_t buckets[2][6]; // [previous-was-tactical][current-captured-piece]
+
+        inline int16_t &bucketRef(const Position *pos, const Move prevMove, const Move currMove) {
+            int capturedPiece = isEnpassant(currMove) ? PAWN : GetPieceType(pos->PieceOn(To(currMove)));
+            if (capturedPiece == EMPTY) capturedPiece = KING; // Impossible to capture kings so we use it as "Empty" slot to save space
+            return buckets[isTactical(prevMove)][capturedPiece];
+        };
+
+        inline int16_t bucket(const Position *pos, const Move prevMove, const Move currMove) const {
+            int capturedPiece = isEnpassant(currMove) ? PAWN : GetPieceType(pos->PieceOn(To(currMove)));
+            if (capturedPiece == EMPTY) capturedPiece = KING; // Impossible to capture kings so we use it as "Empty" slot to save space
+            return buckets[isTactical(prevMove)][capturedPiece];
+        };
     };
 
-    // Indexed by [previous-piece][previous-to][current-piece][current-to]
+    // Indexed by [previous-piece-to][current-piece-to]
     ContinuationHistoryEntry table[12 * 64][12 * 64];
 
-    inline ContinuationHistoryEntry getEntry(const Position *pos, const Move prevMove, const Move currMove) const {
+    inline ContinuationHistoryEntry getEntry(const Move prevMove, const Move currMove) const {
         return table[PieceTo(prevMove)][PieceTo(currMove)];
     };
 
-    inline ContinuationHistoryEntry &getEntryRef(const Position *pos, const Move prevMove, const Move currMove) {
+    inline ContinuationHistoryEntry &getEntryRef(const Move prevMove, const Move currMove) {
         return table[PieceTo(prevMove)][PieceTo(currMove)];
     };
 

--- a/src/history.h
+++ b/src/history.h
@@ -89,26 +89,21 @@ struct TacticalHistoryTable {
 struct ContinuationHistoryTable {
     struct ContinuationHistoryEntry {
         int16_t factoriser;
-        int16_t buckets[2][2]; // [previous-was-tactical][current-is-tactical]
-
-        inline int16_t &bucketRef(const Move prevMove, const Move currMove) {
-            return buckets[isTactical(prevMove)][isTactical(currMove)];
-        };
-
-        inline int16_t bucket(const Move prevMove, const Move currMove) const {
-            return buckets[isTactical(prevMove)][isTactical(currMove)];
-        };
     };
 
-    // Indexed by [previous-piece-to][current-piece-to]
-    ContinuationHistoryEntry table[12 * 64][12 * 64];
+    // Indexed by [previous-piece-to][current-piece-to][current-captured-piece]
+    ContinuationHistoryEntry table[12 * 64][12 * 64][6];
 
-    inline ContinuationHistoryEntry getEntry(const Move prevMove, const Move currMove) const {
-        return table[PieceTo(prevMove)][PieceTo(currMove)];
+    inline ContinuationHistoryEntry getEntry(const Position *pos, const Move prevMove, const Move currMove) const {
+        int capturedPiece = isEnpassant(currMove) ? PAWN : GetPieceType(pos->PieceOn(To(currMove)));
+        if (capturedPiece == EMPTY) capturedPiece = KING; // Impossible to capture kings so we use it as "Empty" slot to save space
+        return table[PieceTo(prevMove)][PieceTo(currMove)][capturedPiece];
     };
 
-    inline ContinuationHistoryEntry &getEntryRef(const Move prevMove, const Move currMove) {
-        return table[PieceTo(prevMove)][PieceTo(currMove)];
+    inline ContinuationHistoryEntry &getEntryRef(const Position *pos, const Move prevMove, const Move currMove) {
+        int capturedPiece = isEnpassant(currMove) ? PAWN : GetPieceType(pos->PieceOn(To(currMove)));
+        if (capturedPiece == EMPTY) capturedPiece = KING; // Impossible to capture kings so we use it as "Empty" slot to save space
+        return table[PieceTo(prevMove)][PieceTo(currMove)][capturedPiece];
     };
 
     inline void clear() {

--- a/src/history.h
+++ b/src/history.h
@@ -89,18 +89,14 @@ struct TacticalHistoryTable {
 struct ContinuationHistoryTable {
     struct ContinuationHistoryEntry {
         int16_t factoriser;
-        int16_t buckets[2][6]; // [previous-was-tactical][current-captured-piece]
+        int16_t buckets[2][2]; // [previous-was-tactical][current-is-tactical]
 
-        inline int16_t &bucketRef(const Position *pos, const Move prevMove, const Move currMove) {
-            int capturedPiece = isEnpassant(currMove) ? PAWN : GetPieceType(pos->PieceOn(To(currMove)));
-            if (capturedPiece == EMPTY) capturedPiece = KING; // Impossible to capture kings so we use it as "Empty" slot to save space
-            return buckets[isTactical(prevMove)][capturedPiece];
+        inline int16_t &bucketRef(const Move prevMove, const Move currMove) {
+            return buckets[isTactical(prevMove)][isTactical(currMove)];
         };
 
-        inline int16_t bucket(const Position *pos, const Move prevMove, const Move currMove) const {
-            int capturedPiece = isEnpassant(currMove) ? PAWN : GetPieceType(pos->PieceOn(To(currMove)));
-            if (capturedPiece == EMPTY) capturedPiece = KING; // Impossible to capture kings so we use it as "Empty" slot to save space
-            return buckets[isTactical(prevMove)][capturedPiece];
+        inline int16_t bucket(const Move prevMove, const Move currMove) const {
+            return buckets[isTactical(prevMove)][isTactical(currMove)];
         };
     };
 

--- a/src/ttable.cpp
+++ b/src/ttable.cpp
@@ -34,9 +34,7 @@ void AlignedFree(void *src) {
 }
 
 void ClearTT() {
-    for (uint64_t i = 0; i < TT.paddedSize / sizeof(TTBucket); ++i) {
-        TT.pTable[i] = TTBucket();
-    }
+    std::fill(TT.pTable, TT.pTable + (TT.paddedSize / sizeof(TTBucket)), TTBucket());
     TT.age = 1;
 }
 

--- a/src/tune.h
+++ b/src/tune.h
@@ -120,12 +120,14 @@ TUNE_PARAM(histBonusConst, 16, 0, 32, 1.0, 0.002)
 TUNE_PARAM(histBonusMax, 1200, 400, 4800, 100.0, 0.002)
 
 TUNE_PARAM(quietHistFactoriserScale, 16, 0, 64, 2.0, 0.002)
-TUNE_PARAM(quietHistFactoriserMax, 2048, 2048, 20000, 300.0, 0.002)
+TUNE_PARAM(quietHistFactoriserMax, 2048, 2048, 20000, 150.0, 0.002)
 TUNE_PARAM(quietHistBucketMax, 6144, 2048, 20000, 300.0, 0.002)
 
 TUNE_PARAM(tacticalHistMax, 8192, 4096, 20000, 300.0, 0.002)
 
-TUNE_PARAM(continuationHistMax, 16384, 8192, 32767, 300.0, 0.002)
+TUNE_PARAM(continuationHistFactoriserScale, 16, 0, 64, 2.0, 0.002)
+TUNE_PARAM(continuationHistFactoriserMax, 4096, 2048, 8192, 150.0, 0.002)
+TUNE_PARAM(continuationHistBucketMax, 12288, 6144, 32767, 300.0, 0.002)
 
 TUNE_PARAM(corrHistMaxAdjust, 22528, 16384, 32767, 800.0, 0.002)
 TUNE_PARAM(corrHistWeightQuadratic, 4, 0, 8, 0.5, 0.002)

--- a/src/tune.h
+++ b/src/tune.h
@@ -125,9 +125,7 @@ TUNE_PARAM(quietHistBucketMax, 6144, 2048, 20000, 300.0, 0.002)
 
 TUNE_PARAM(tacticalHistMax, 8192, 4096, 20000, 300.0, 0.002)
 
-TUNE_PARAM(continuationHistFactoriserScale, 16, 0, 64, 2.0, 0.002)
-TUNE_PARAM(continuationHistFactoriserMax, 4096, 2048, 8192, 150.0, 0.002)
-TUNE_PARAM(continuationHistBucketMax, 12288, 6144, 32767, 300.0, 0.002)
+TUNE_PARAM(continuationHistMax, 16384, 8192, 32767, 300.0, 0.002)
 
 TUNE_PARAM(corrHistMaxAdjust, 22528, 16384, 32767, 800.0, 0.002)
 TUNE_PARAM(corrHistWeightQuadratic, 4, 0, 8, 0.5, 0.002)


### PR DESCRIPTION
Elo   | 3.69 +- 2.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 15988 W: 3908 L: 3738 D: 8342
Penta | [82, 1867, 3950, 1989, 106]
https://chess.swehosting.se/test/7910/

Bench 9823563