### PR TITLE
Use TT info to adjust eval

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -329,8 +329,16 @@ int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td) {
     return score;
 }
 
-void adjustEval(Position *pos, SearchData *sd, int rawEval, int &staticEval, int &eval) {
-    staticEval = eval = sd->correctionHistory.adjust(pos, rawEval);
+void adjustEval(Position *pos, SearchData *sd, int rawEval, int &staticEval, int &eval, int ttScore, uint8_t ttBound) {
+    staticEval = sd->correctionHistory.adjust(pos, rawEval);
+
+    if (    ttScore != SCORE_NONE
+        && (   (ttBound == HFUPPER && ttScore < eval) // TT score is a better upper bound
+            || (ttBound == HFLOWER && ttScore > eval) // TT score is a better lower bound
+            ||  ttBound == HFEXACT))
+        eval = ttScore;
+    else
+        eval = staticEval;
 }
 
 // Negamax alpha beta search
@@ -418,12 +426,12 @@ int Negamax(int alpha, int beta, int depth, ThreadData* td, SearchStack* ss, Mov
     else if (ttHit) {
         // If the value in the TT is valid we use that, otherwise we call the static evaluation function
         rawEval = eval = ss->staticEval = tte.eval != SCORE_NONE ? tte.eval : EvalPosition(pos);
-        adjustEval(pos, sd, rawEval, ss->staticEval, eval);
+        adjustEval(pos, sd, rawEval, ss->staticEval, eval, ttScore, ttBound);
     }
     else {
         // If we don't have anything in the TT we have to call evalposition
         rawEval = eval = ss->staticEval = EvalPosition(pos);
-        adjustEval(pos, sd, rawEval, ss->staticEval, eval);
+        adjustEval(pos, sd, rawEval, ss->staticEval, eval, ttScore, ttBound);
 
         // Save the eval into the TT
         StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
@@ -708,12 +716,12 @@ int Quiescence(int alpha, int beta, ThreadData* td, SearchStack* ss) {
     else if (ttHit) {
         // If the value in the TT is valid we use that, otherwise we call the static evaluation function
         rawEval = ss->staticEval = bestScore = tte.eval != SCORE_NONE ? tte.eval : EvalPosition(pos);
-        adjustEval(pos, sd, rawEval, ss->staticEval, bestScore);
+        adjustEval(pos, sd, rawEval, ss->staticEval, bestScore, ttScore, ttBound);
     }
     // If we don't have any useful info in the TT just call Evalpos
     else {
         rawEval = bestScore = ss->staticEval = EvalPosition(pos);
-        adjustEval(pos, sd, rawEval, ss->staticEval, bestScore);
+        adjustEval(pos, sd, rawEval, ss->staticEval, bestScore, ttScore, ttBound);
         // Save the eval into the TT
         StoreTTEntry(pos->posKey, NOMOVE, SCORE_NONE, rawEval, HFNONE, 0, pvNode, ttPv);
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -332,6 +332,7 @@ int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td) {
 void adjustEval(Position *pos, SearchData *sd, int rawEval, int &staticEval, int &eval, int ttScore, uint8_t ttBound) {
     staticEval = sd->correctionHistory.adjust(pos, rawEval);
 
+    // Adjust eval using TT score if it is more accurate
     if (    ttScore != SCORE_NONE
         && (   (ttBound == HFUPPER && ttScore < eval) // TT score is a better upper bound
             || (ttBound == HFLOWER && ttScore > eval) // TT score is a better lower bound

--- a/src/search.h
+++ b/src/search.h
@@ -53,7 +53,7 @@ void SearchPosition(int start_depth, int final_depth, ThreadData* td, UciOptions
 [[nodiscard]] int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td);
 
 // Adjusts eval and sets the different eval variables
-void adjustEval(Position *pos, SearchData *sd, int rawEval, int &staticEval, int &eval);
+void adjustEval(Position *pos, SearchData *sd, int rawEval, int &staticEval, int &eval, int ttScore, uint8_t ttBound);
 
 // Negamax alpha beta search
 template <bool pvNode>


### PR DESCRIPTION
Elo   | 17.56 +- 7.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2376 W: 632 L: 512 D: 1232
Penta | [9, 241, 585, 327, 26]
https://chess.swehosting.se/test/7911/

Bench 8778771