### PR TITLE
Add "improving" heuristic to reverse futility pruning

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -157,7 +157,7 @@ void InitReductions() {
                 lmrReductions[moves][depth] = 0;
                 continue;
             }
-            lmrReductions[moves][depth] = (double(quietLmrBase()) + double(quietLmrMult()) * std::log(depth) * std::log(moves)) / 1024;
+            lmrReductions[moves][depth] = double(quietLmrBase()) + double(quietLmrMult()) * std::log(depth) * std::log(moves);
         }
     }
 }

--- a/src/tune.h
+++ b/src/tune.h
@@ -82,8 +82,11 @@ TUNE_PARAM(minAspDepth, 4, 2, 6, 0.5, 0.002)
 TUNE_PARAM(aspWindowStart, 10, 8, 15, 0.5, 0.002)
 TUNE_PARAM(aspWindowWidenScale, 81, 65, 128, 3.0, 0.002)
 
-TUNE_PARAM(rfpDepth, 8, 4, 14, 0.5, 0.002)
-TUNE_PARAM(rfpCoeff, 70, 20, 200, 10.0, 0.002)
+TUNE_PARAM(maxImprovementPer256, 384, 256, 512, 13.0, 0.002)
+
+TUNE_PARAM(rfpMaxDepth, 8, 4, 14, 0.5, 0.002)
+TUNE_PARAM(rfpDepthCoeff, 70, 20, 200, 10.0, 0.002)
+TUNE_PARAM(rfpImprCoeff, 70, 20, 200, 10.0, 0.002)
 
 TUNE_PARAM(nmpDepth, 3, 1, 5, 0.5, 0.002)
 TUNE_PARAM(nmpRedConst, 3072, 1024, 5120, 400.0, 0.002)


### PR DESCRIPTION
Elo   | 14.31 +- 6.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2988 W: 783 L: 660 D: 1545
Penta | [18, 313, 716, 422, 25]
https://chess.swehosting.se/test/7924/

Bench 8048422