### PR TITLE
Carry out LMR for tactical moves on non TTPV nodes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -154,10 +154,12 @@ void InitReductions() {
         for (int moves = 0; moves < 64; ++moves) {
             // Manually set reduction to 0 if depth or moves is 0 as log(0) is NaN
             if (depth == 0 || moves == 0) {
-                lmrReductions[moves][depth] = 0;
+                lmrReductions[0][moves][depth] = 0;
+                lmrReductions[1][moves][depth] = 0;
                 continue;
             }
-            lmrReductions[moves][depth] = double(quietLmrBase()) + double(quietLmrMult()) * std::log(depth) * std::log(moves);
+            lmrReductions[0][moves][depth] = double(tacticalLmrBase()) + double(tacticalLmrMult()) * std::log(depth) * std::log(moves); // Tactical LMR
+            lmrReductions[1][moves][depth] = double(quietLmrBase()) + double(quietLmrMult()) * std::log(depth) * std::log(moves); // Quiet LMR
         }
     }
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -451,7 +451,8 @@ int Negamax(int alpha, int beta, int depth, ThreadData* td, SearchStack* ss, Mov
 
     const int improvement = ss->staticEval - prevEval;
     const bool improving = improvement > 0;
-    const int improvementPer256 = std::clamp(improvement / std::abs(prevEval), -maxImprovementPer256(), maxImprovementPer256());
+    const int improvementPer256 = prevEval == 0 ? maxImprovementPer256()
+                                                : std::clamp(improvement / std::abs(prevEval), -maxImprovementPer256(), maxImprovementPer256());
 
     if (   !pvNode
         && !excludedMove
@@ -586,10 +587,10 @@ int Negamax(int alpha, int beta, int depth, ThreadData* td, SearchStack* ss, Mov
         // Here we calulate the reduction that we are going to reduce for this move.
         if (   depth >= 3
             && totalMoves > 1 + pvNode
-            && isQuiet) {
+            && (isQuiet || !ttPv)) {
 
             // Get base reduction value
-            int depthReduction = lmrReductions[std::min(depth, 63)][std::min(totalMoves, 63)] / 1024;
+            int depthReduction = lmrReductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)] / 1024;
 
             // Clamp the reduced search depth so that we neither extend nor drop into qsearch
             // We use min/max instead of clamp due to issues that can arise if newDepth < 1

--- a/src/search.h
+++ b/src/search.h
@@ -7,7 +7,7 @@
 
 inline int seeMargins[2][64];
 inline int futilityMargins[64];
-inline int lmrReductions[64][64];
+inline int lmrReductions[2][64][64];
 inline int lmpMargins[64];
 
 struct SearchStack {

--- a/src/tune.h
+++ b/src/tune.h
@@ -117,6 +117,9 @@ TUNE_PARAM(seDePvCoeff, 400, 0, 450, 30.0, 0.002)
 TUNE_PARAM(quietLmrBase, 1690, 0, 2535, 128.0, 0.002)
 TUNE_PARAM(quietLmrMult, 366, 244, 549, 32.0, 0.002)
 
+TUNE_PARAM(tacticalLmrBase, 338, 244, 549, 32.0, 0.002)
+TUNE_PARAM(tacticalLmrMult, 320, 244, 549, 32.0, 0.002)
+
 TUNE_PARAM(histBonusQuadratic, 16, 0, 32, 1.0, 0.002)
 TUNE_PARAM(histBonusLinear, 32, 0, 64, 2.0, 0.002)
 TUNE_PARAM(histBonusConst, 16, 0, 32, 1.0, 0.002)


### PR DESCRIPTION
Elo   | 1.35 +- 1.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 116784 W: 27983 L: 27528 D: 61273
Penta | [754, 13837, 28722, 14358, 721]
https://chess.swehosting.se/test/7956/

Bench 7477616