### PR TITLE
Tweak LMR reduction based on TTPV

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -601,6 +601,9 @@ int Negamax(int alpha, int beta, int depth, ThreadData* td, SearchStack* ss, Mov
             // Get base reduction value
             int depthReduction = lmrReductions[isQuiet][std::min(depth, 63)][std::min(totalMoves, 63)] / 1024;
 
+            // Reduce less if we are on or have been on the PV
+            if (ttPv) depthReduction -= 1;
+
             // Clamp the reduced search depth so that we neither extend nor drop into qsearch
             // We use min/max instead of clamp due to issues that can arise if newDepth < 1
             int reducedDepth = std::min(std::max(newDepth - depthReduction, 1), newDepth);


### PR DESCRIPTION
Elo   | 5.66 +- 3.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8602 W: 2102 L: 1962 D: 4538
Penta | [42, 968, 2136, 1118, 37]
https://chess.swehosting.se/test/8006/

Bench 11934869