### PR TITLE
Use search result prediction to tweak LMR reduction

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -57,7 +57,7 @@ void adjustEval(Position *pos, SearchData *sd, int rawEval, int &staticEval, int
 
 // Negamax alpha beta search
 template <bool pvNode>
-[[nodiscard]] int Negamax(int alpha, int beta, int depth, ThreadData* td, SearchStack* ss, Move excludedMove = NOMOVE);
+[[nodiscard]] int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* td, SearchStack* ss, Move excludedMove = NOMOVE);
 
 // Quiescence search to avoid the horizon effect
 template <bool pvNode>

--- a/src/tune.h
+++ b/src/tune.h
@@ -127,6 +127,9 @@ TUNE_PARAM(quietLmrMult, 366, 244, 549, 32.0, 0.002)
 TUNE_PARAM(tacticalLmrBase, 338, 244, 549, 32.0, 0.002)
 TUNE_PARAM(tacticalLmrMult, 320, 244, 549, 32.0, 0.002)
 
+TUNE_PARAM(ttPvLmrReduction, 1024, 512, 1536, 128, 0.002)
+TUNE_PARAM(predictedCutNodeLmrReduction, 2048, 1024, 3072, 256, 0.002)
+
 TUNE_PARAM(histBonusQuadratic, 16, 0, 32, 1.0, 0.002)
 TUNE_PARAM(histBonusLinear, 32, 0, 64, 2.0, 0.002)
 TUNE_PARAM(histBonusConst, 16, 0, 32, 1.0, 0.002)


### PR DESCRIPTION
Elo   | 3.28 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 18864 W: 4665 L: 4487 D: 9712
Penta | [82, 2183, 4743, 2323, 101]
https://chess.swehosting.se/test/8008/

Bench 18276242