### PR TITLE
Weight history bonus or malus based on the number of times the move was searched

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -18,7 +18,8 @@ inline int16_t HistoryBonus(const int depth) {
 }
 
 inline void UpdateHistoryEntry(int16_t &entry, const int16_t bonus, const int16_t max) {
-    const int scaledBonus = bonus - entry * std::abs(bonus) / max;
+    const int clampedBonus = std::clamp<int16_t>(bonus, -max, max);
+    const int scaledBonus  = clampedBonus - entry * std::abs(clampedBonus) / max;
     entry += scaledBonus;
 }
 


### PR DESCRIPTION
Elo   | 4.77 +- 3.44 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10642 W: 2595 L: 2449 D: 5598
Penta | [43, 1202, 2683, 1352, 41]
https://chess.swehosting.se/test/8117/

Bench 16290685