### PR TITLE
Adjust reduction if move gives check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -613,7 +613,10 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
             // Reduce less if we are on or have been on the PV
             if (ttPv) depthReductionGranular -= ttPvLmrReduction();
 
-            // Reduce less if we are predicted to fail high (i.e. we stem from an LMR search earlier in the tree)
+            // Reduce less if the move gave check
+            if (pos->getCheckers()) depthReductionGranular -= givesCheckReduction();
+
+            // Reduce more if we are predicted to fail high (i.e. we stem from an LMR search earlier in the tree)
             if (predictedCutNode) depthReductionGranular += predictedCutNodeLmrReduction();
 
             // Divide by 1024 once all the adjustments have been applied

--- a/src/tune.h
+++ b/src/tune.h
@@ -137,6 +137,7 @@ TUNE_PARAM(tacticalLmrMult, 320, 244, 549, 32.0, 0.002)
 
 TUNE_PARAM(ttPvLmrReduction, 1024, 512, 1536, 128, 0.002)
 TUNE_PARAM(predictedCutNodeLmrReduction, 2048, 1024, 3072, 256, 0.002)
+TUNE_PARAM(givesCheckReduction, 1024, 512, 1536, 128, 0.002)
 
 TUNE_PARAM(doDeeperBaseScore, 53, 20, 100, 6, 0.002)
 TUNE_PARAM(doDeeperDepthMultiplier, 2, 1, 4, 0.5, 0.002)


### PR DESCRIPTION
Elo   | 5.63 +- 3.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 4.00]
Games | N: 10612 W: 2680 L: 2508 D: 5424
Penta | [59, 1244, 2556, 1360, 87]
https://chess.swehosting.se/test/8139/

Bench 9755587