### PR TITLE
Tweak history bonus/malus based on eval

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -75,18 +75,19 @@ int16_t CorrectionHistoryTable::adjust(const Position *pos, const int eval) cons
 }
 
 // Use this function to update all quiet histories
-void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int depth, const Move bestMove, const MoveList &quietMoves, const MoveList &tacticalMoves) {
-    const int16_t bonus = HistoryBonus(depth);
+void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int bonusDepth, const int malusDepth, const Move bestMove, const MoveList &quietMoves, const MoveList &tacticalMoves) {
+    const int16_t bonus =  HistoryBonus(bonusDepth);
+    const int16_t malus = -HistoryBonus(malusDepth);
 
     // Scale the bonus/malus on the number of times the move was searched
-    auto scaleUpdate = [](const int update, const int searchedTimes) { return update * (searchedTimes + 1) / 2; };
+    auto scaleUpdate = [](const int update, const int searchedTimes) { return update * searchedTimes; };
 
     if (!isTactical(bestMove)) {
         // Positively update best move
         // Penalise all quiets that failed to do so (they were ordered earlier but weren't as good)
         for (int i = 0; i < quietMoves.count; ++i) {
             Move quiet = quietMoves.moves[i].move;
-            int update = bestMove == quiet ? bonus : -bonus;
+            int update = bestMove == quiet ? bonus : malus;
             update = scaleUpdate(update, quietMoves.moves[i].score);
             sd->quietHistory.update(pos, quiet, update);
             sd->continuationHistory.update(pos, ss, quiet, update);
@@ -97,7 +98,7 @@ void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *
     // Penalise all tactical moves that were searched first but didn't fail high (even if the best move was quiet)
     for (int i = 0; i < tacticalMoves.count; ++i) {
         Move tactical = tacticalMoves.moves[i].move;
-        int update = bestMove == tactical ? bonus : -bonus;
+        int update = bestMove == tactical ? bonus : malus;
         update = scaleUpdate(update, tacticalMoves.moves[i].score);
         sd->tacticalHistory.update(pos, tactical, update);
         sd->continuationHistory.update(pos, ss, tactical, update);

--- a/src/history.h
+++ b/src/history.h
@@ -151,7 +151,7 @@ struct CorrectionHistoryTable {
 };
 
 // Update all histories after a beta cutoff
-void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int depth, const Move bestMove, const MoveList &quietMoves, const MoveList &tacticalMoves);
+void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int bonusDepth, const int malusDepth, const Move bestMove, const MoveList &quietMoves, const MoveList &tacticalMoves);
 
 // Get history score for a given move
 int GetHistoryScore(const Position *pos, const SearchStack *ss, const SearchData *sd, const Move move);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -702,9 +702,11 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
                 // node (move) fails high
                 if (score >= beta) {
-                    // increase bonus if our static eval suggested we were failing low
-                    const int bonusDepth = depth + (ss->staticEval <= alpha);
-                    const int malusDepth = depth;
+                    // Increase bonus if our eval suggested we were failing low,
+                    // and decrease bonus if our eval suggested we were failing high (the fail-high was according to expectations)
+                    // Do the opposite for malus (as the search result was opposite vs best move)
+                    const int bonusDepth = depth + (eval <= alpha) - (eval >= beta);
+                    const int malusDepth = depth - (eval <= alpha) + (eval >= beta);
                     UpdateAllHistories(pos, ss, sd, bonusDepth, malusDepth, move, quietMoves, tacticalMoves);
                     break;
                 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -700,9 +700,12 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
                     pvTable->pvLength[ss->ply] = pvTable->pvLength[ss->ply + 1];
                 }
 
+                // node (move) fails high
                 if (score >= beta) {
-                    // node (move) fails high
-                    UpdateAllHistories(pos, ss, sd, depth, move, quietMoves, tacticalMoves);
+                    // increase bonus if our static eval suggested we were failing low
+                    const int bonusDepth = depth + (ss->staticEval <= alpha);
+                    const int malusDepth = depth;
+                    UpdateAllHistories(pos, ss, sd, bonusDepth, malusDepth, move, quietMoves, tacticalMoves);
                     break;
                 }
                 // Update alpha iff alpha < beta

--- a/src/tune.h
+++ b/src/tune.h
@@ -144,9 +144,9 @@ TUNE_PARAM(givesCheckReduction, 1024, 512, 1536, 128, 0.002)
 TUNE_PARAM(doDeeperBaseScore, 53, 20, 100, 6, 0.002)
 TUNE_PARAM(doDeeperDepthMultiplier, 2, 1, 4, 0.5, 0.002)
 
-TUNE_PARAM(histBonusQuadratic, 15, 0, 32, 1.0, 0.002)
-TUNE_PARAM(histBonusLinear, 30, 0, 64, 2.0, 0.002)
-TUNE_PARAM(histBonusConst, 15, 0, 32, 1.0, 0.002)
+TUNE_PARAM(histBonusQuadratic, 16, 0, 32, 1.0, 0.002)
+TUNE_PARAM(histBonusLinear, 32, 0, 64, 2.0, 0.002)
+TUNE_PARAM(histBonusConst, 16, 0, 32, 1.0, 0.002)
 TUNE_PARAM(histBonusMax, 1200, 400, 4800, 100.0, 0.002)
 
 TUNE_PARAM(quietHistFactoriserScale, 16, 0, 64, 2.0, 0.002)

--- a/src/tune.h
+++ b/src/tune.h
@@ -144,9 +144,9 @@ TUNE_PARAM(givesCheckReduction, 1024, 512, 1536, 128, 0.002)
 TUNE_PARAM(doDeeperBaseScore, 53, 20, 100, 6, 0.002)
 TUNE_PARAM(doDeeperDepthMultiplier, 2, 1, 4, 0.5, 0.002)
 
-TUNE_PARAM(histBonusQuadratic, 16, 0, 32, 1.0, 0.002)
-TUNE_PARAM(histBonusLinear, 32, 0, 64, 2.0, 0.002)
-TUNE_PARAM(histBonusConst, 16, 0, 32, 1.0, 0.002)
+TUNE_PARAM(histBonusQuadratic, 15, 0, 32, 1.0, 0.002)
+TUNE_PARAM(histBonusLinear, 30, 0, 64, 2.0, 0.002)
+TUNE_PARAM(histBonusConst, 15, 0, 32, 1.0, 0.002)
 TUNE_PARAM(histBonusMax, 1200, 400, 4800, 100.0, 0.002)
 
 TUNE_PARAM(quietHistFactoriserScale, 16, 0, 64, 2.0, 0.002)


### PR DESCRIPTION
Elo   | 6.31 +- 3.82 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8976 W: 2167 L: 2004 D: 4805
Penta | [44, 1012, 2215, 1171, 46]
https://chess.swehosting.se/test/8228/

Bench 4854473