### PR TITLE
Reduce aspiration search depth on fail highs

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -75,20 +75,42 @@ int16_t CorrectionHistoryTable::adjust(const Position *pos, const int eval) cons
 }
 
 // Use this function to update all quiet histories
-void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int bonusDepth, const int malusDepth, const Move bestMove, const MoveList &quietMoves, const MoveList &tacticalMoves) {
-    const int16_t bonus =  HistoryBonus(bonusDepth);
-    const int16_t malus = -HistoryBonus(malusDepth);
+void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int depth, const Move bestMove,
+                        const SearchedMoveList &quietMoves, const SearchedMoveList &tacticalMoves, const int eval, const int alpha, const int beta) {
 
-    // Scale the bonus/malus on the number of times the move was searched
-    auto scaleUpdate = [](const int update, const int searchedTimes) { return update * searchedTimes; };
+    auto getBonus = [&](const SearchedMove move) {
+        int bonusDepth = depth;
+
+        // Increase bonus if our eval suggested we were failing low (result was against expectations)
+        if (eval <= alpha) bonusDepth += 1;
+
+        // Decrease bonus if our eval suggested we were failing high (result was expected outcome)
+        if (eval >= beta) bonusDepth -= 1;
+
+        // Double the bonus if the move passed through LMR
+        return HistoryBonus(bonusDepth) * (1 + move.didLMR);
+    };
+
+    auto getMalus = [&](const SearchedMove move) {
+        int malusDepth = depth;
+
+        // Decrease malus if our eval suggested we were failing low (result was expected outcome for this move)
+        if (eval <= alpha) malusDepth -= 1;
+
+        // Increase malus if our eval suggested we were failing high (result was against expectations for this move)
+        if (eval >= beta) malusDepth += 1;
+
+        // Double the malus if we did a full depth search on the move
+        return -HistoryBonus(malusDepth) * (1 + move.didFullDepthSearch);
+    };
 
     if (!isTactical(bestMove)) {
         // Positively update best move
         // Penalise all quiets that failed to do so (they were ordered earlier but weren't as good)
         for (int i = 0; i < quietMoves.count; ++i) {
-            Move quiet = quietMoves.moves[i].move;
-            int update = bestMove == quiet ? bonus : malus;
-            update = scaleUpdate(update, quietMoves.moves[i].score);
+            SearchedMove quietData = quietMoves.moves[i];
+            Move quiet = quietData.move;
+            int update = quiet == bestMove ? getBonus(quietData) : getMalus(quietData);
             sd->quietHistory.update(pos, quiet, update);
             sd->continuationHistory.update(pos, ss, quiet, update);
         }
@@ -97,9 +119,9 @@ void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *
     // Positively update best move
     // Penalise all tactical moves that were searched first but didn't fail high (even if the best move was quiet)
     for (int i = 0; i < tacticalMoves.count; ++i) {
-        Move tactical = tacticalMoves.moves[i].move;
-        int update = bestMove == tactical ? bonus : malus;
-        update = scaleUpdate(update, tacticalMoves.moves[i].score);
+        SearchedMove tacticalData = tacticalMoves.moves[i];
+        Move tactical = tacticalData.move;
+        int update = tactical == bestMove ? getBonus(tacticalData) : getMalus(tacticalData);
         sd->tacticalHistory.update(pos, tactical, update);
         sd->continuationHistory.update(pos, ss, tactical, update);
     }

--- a/src/history.h
+++ b/src/history.h
@@ -11,6 +11,28 @@ struct SearchData;
 struct SearchStack;
 struct MoveList;
 
+struct SearchedMove {
+    Move move;
+    bool didLMR;
+    bool didFullDepthSearch;
+    SearchedMove() {};
+
+    SearchedMove(Move m, bool dLMR, bool dFDS) {
+        move = m;
+        didLMR = dLMR;
+        didFullDepthSearch = dFDS;
+    };
+};
+
+struct SearchedMoveList {
+    int count = 0;
+    SearchedMove moves[256];
+    inline void add(SearchedMove searchedMove) {
+        moves[count] = searchedMove;
+        count++;
+    };
+};
+
 inline int16_t HistoryBonus(const int depth) {
     return std::min(  histBonusQuadratic() * depth * depth
                     + histBonusLinear() * depth
@@ -151,7 +173,8 @@ struct CorrectionHistoryTable {
 };
 
 // Update all histories after a beta cutoff
-void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int bonusDepth, const int malusDepth, const Move bestMove, const MoveList &quietMoves, const MoveList &tacticalMoves);
+void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *sd, const int depth, const Move bestMove,
+                        const SearchedMoveList &quietMoves, const SearchedMoveList &tacticalMoves, const int eval, const int alpha, const int beta);
 
 // Get history score for a given move
 int GetHistoryScore(const Position *pos, const SearchStack *ss, const SearchData *sd, const Move move);

--- a/src/history.h
+++ b/src/history.h
@@ -14,13 +14,15 @@ struct MoveList;
 struct SearchedMove {
     Move move;
     bool didLMR;
-    bool didFullDepthSearch;
+    bool didZWS;
+    bool didPVS;
     SearchedMove() {};
 
-    SearchedMove(Move m, bool dLMR, bool dFDS) {
+    SearchedMove(Move m, bool dLMR, bool dZWS, bool dPVS) {
         move = m;
         didLMR = dLMR;
-        didFullDepthSearch = dFDS;
+        didZWS = dZWS;
+        didPVS = dPVS;
     };
 };
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -596,7 +596,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
         // we adjust the search depth based on potential extensions
         int newDepth = depth - 1 + extension;
-        bool didLMR = false, didFullDepthSearch = false;
+        bool didLMR = false, didZWS = false, didPVS = false;
 
         // Speculative prefetch of the TT entry
         TTPrefetch(keyAfter(pos, move));
@@ -647,7 +647,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
                 newDepth += doDeeperSearch - doShallowerSearch;
                 if (newDepth > reducedDepth) {
                     score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-                    didFullDepthSearch = true;
+                    didZWS = true;
                 }
             }
         }
@@ -658,18 +658,18 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
         // This zero window search will either confirm or deny our prediction, as the score cannot be exact (no integer lies in (-alpha - 1, -alpha))
         else if (!pvNode || totalMoves > 1) {
             score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-            didFullDepthSearch = true;
+            didZWS = true;
         }
 
         // If this is our first move, we search with a full window.
         // Otherwise, if our zero window search fails low, this is a potential alpha raise and so we search the move fully.
         if (pvNode && (totalMoves == 1 || score > alpha)) {
             score = -Negamax<true>(-beta, -alpha, newDepth, false, td, ss + 1);
-            didFullDepthSearch = true;
+            didPVS = true;
         }
 
         // Add the move to the corresponding list, along with the data on its search
-        SearchedMove moveData(move, didLMR, didFullDepthSearch);
+        SearchedMove moveData(move, didLMR, didZWS, didPVS);
         if (isQuiet) quietMoves.add(moveData);
         else tacticalMoves.add(moveData);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -323,11 +323,13 @@ int AspirationWindowSearch(int prev_eval, int depth, ThreadData* td) {
         if (score <= alpha) {
             beta  = (alpha * aspFailLowAlphaWeight() + beta * (128 - aspFailLowAlphaWeight())) / 128;
             alpha = std::max(-MAXSCORE, score - delta);
+            depth = td->RootDepth;
         }
         // Fail high, move window higher
         else if (score >= beta) {
             alpha = (alpha * aspFailHighAlphaWeight() + beta * (128 - aspFailHighAlphaWeight())) / 128;
             beta  = std::min(MAXSCORE, score + delta);
+            depth = std::max(depth - 1, td->RootDepth - 5);
         }
         // Exact bound, we no longer need to continue searching at this depth
         else break;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -518,7 +518,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
     InitMP(&mp, pos, sd, ss, ttMove, SEARCH);
 
     // Keep track of the played quiet and tactical moves
-    MoveList quietMoves, tacticalMoves;
+    SearchedMoveList quietMoves, tacticalMoves;
 
     // loop over moves within a movelist
     while ((move = NextMove(&mp, skipQuiets)) != NOMOVE) {
@@ -596,8 +596,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
         // we adjust the search depth based on potential extensions
         int newDepth = depth - 1 + extension;
-
-        int searchedTimes = 0;
+        bool didLMR = false, didFullDepthSearch = false;
 
         // Speculative prefetch of the TT entry
         TTPrefetch(keyAfter(pos, move));
@@ -638,7 +637,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
             // Carry out the reduced depth, zero window search
             score = -Negamax<false>(-alpha - 1, -alpha, reducedDepth, true, td, ss + 1);
-            searchedTimes++;
+            didLMR = true;
 
             // If the reduced depth search fails high, do a full depth search (but still on zero window).
             if (score > alpha && newDepth > reducedDepth) {
@@ -648,7 +647,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
                 newDepth += doDeeperSearch - doShallowerSearch;
                 if (newDepth > reducedDepth) {
                     score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-                    searchedTimes++;
+                    didFullDepthSearch = true;
                 }
             }
         }
@@ -659,18 +658,20 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
         // This zero window search will either confirm or deny our prediction, as the score cannot be exact (no integer lies in (-alpha - 1, -alpha))
         else if (!pvNode || totalMoves > 1) {
             score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-            searchedTimes++;
+            didFullDepthSearch = true;
         }
 
         // If this is our first move, we search with a full window.
         // Otherwise, if our zero window search fails low, this is a potential alpha raise and so we search the move fully.
         if (pvNode && (totalMoves == 1 || score > alpha)) {
             score = -Negamax<true>(-beta, -alpha, newDepth, false, td, ss + 1);
-            searchedTimes++;
+            didFullDepthSearch = true;
         }
 
-        // Add the move to the corresponding list, along with the number of times it was searched
-        AddMove(move, searchedTimes, isQuiet ? &quietMoves : &tacticalMoves);
+        // Add the move to the corresponding list, along with the data on its search
+        SearchedMove moveData(move, didLMR, didFullDepthSearch);
+        if (isQuiet) quietMoves.add(moveData);
+        else tacticalMoves.add(moveData);
 
         // take move back
         UnmakeMove(move, pos);
@@ -702,12 +703,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
                 // node (move) fails high
                 if (score >= beta) {
-                    // Increase bonus if our eval suggested we were failing low,
-                    // and decrease bonus if our eval suggested we were failing high (the fail-high was according to expectations)
-                    // Do the opposite for malus (as the search result was opposite vs best move)
-                    const int bonusDepth = depth + (eval <= alpha) - (eval >= beta);
-                    const int malusDepth = depth - (eval <= alpha) + (eval >= beta);
-                    UpdateAllHistories(pos, ss, sd, bonusDepth, malusDepth, move, quietMoves, tacticalMoves);
+                    UpdateAllHistories(pos, ss, sd, depth, move, quietMoves, tacticalMoves, eval, alpha, beta);
                     break;
                 }
                 // Update alpha iff alpha < beta


### PR DESCRIPTION
Elo   | 6.42 +- 3.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8766 W: 2122 L: 1960 D: 4684
Penta | [38, 989, 2188, 1109, 59]
https://chess.swehosting.se/test/8253/

Bench 3169012