### PR TITLE
Change bonus/malus scaling to original intended purpose

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -87,9 +87,7 @@ void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *
         // Decrease bonus if our eval suggested we were failing high (result was expected outcome)
         if (eval >= beta) bonusDepth -= 1;
 
-        // If a full window search was performed, give an x1 multiplier.
-        // Then, if a full depth zero-window search was performed, give an x2 multiplier.
-        // In the base case, give an x3 multiplier.
+        // Scale bonus higher based on our earliest stage (ie, how underestimated the move was)
         const int bonusMultiplier = move.bonusScale();
 
         return HistoryBonus(bonusDepth) * bonusMultiplier;
@@ -104,9 +102,7 @@ void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *
         // Increase malus if our eval suggested we were failing high (result was against expectations for this move)
         if (eval >= beta) malusDepth += 1;
 
-        // If a full window search was performed, give an x3 multiplier.
-        // Then, if a full depth zero-window search was performed, give an x2 multiplier.
-        // In the base case, give an x1 multiplier.
+        // Scale it higher based on how far we searched before failing low
         const int malusMultiplier = move.malusScale();
 
         return -HistoryBonus(malusDepth) * malusMultiplier;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -87,12 +87,10 @@ void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *
         // Decrease bonus if our eval suggested we were failing high (result was expected outcome)
         if (eval >= beta) bonusDepth -= 1;
 
-        // If this best move had to go through LMR, give a x3 multiplier.
-        // If this move skipped LMR but had to do a ZWS (not thought as best during ordering), give a x2 multiplier.
-        // Otherwise, if the move only went thorugh PVS, it was already thought as best and so give a x1 multiplier.
-        const int bonusMultiplier = move.didLMR ? 3
-                                  : move.didZWS ? 2
-                                                : 1;
+        // If a full window search was performed, give an x1 multiplier.
+        // Then, if a full depth zero-window search was performed, give an x2 multiplier.
+        // In the base case, give an x3 multiplier.
+        const int bonusMultiplier = move.bonusScale();
 
         return HistoryBonus(bonusDepth) * bonusMultiplier;
     };
@@ -106,12 +104,10 @@ void UpdateAllHistories(const Position *pos, const SearchStack *ss, SearchData *
         // Increase malus if our eval suggested we were failing high (result was against expectations for this move)
         if (eval >= beta) malusDepth += 1;
 
-        // If a full window search was performed on this non-best move, give an x3 multiplier.
+        // If a full window search was performed, give an x3 multiplier.
         // Then, if a full depth zero-window search was performed, give an x2 multiplier.
-        // If we failed in the LMR search, give an x1 multiplier as it is the most expected outcome.
-        const int malusMultiplier = move.didPVS ? 3
-                                  : move.didZWS ? 2
-                                                : 1;
+        // In the base case, give an x1 multiplier.
+        const int malusMultiplier = move.malusScale();
 
         return -HistoryBonus(malusDepth) * malusMultiplier;
     };

--- a/src/history.h
+++ b/src/history.h
@@ -11,19 +11,30 @@ struct SearchData;
 struct SearchStack;
 struct MoveList;
 
+enum ScalingFactor {
+     None,
+     didPVS,
+     didZWS,
+     didLMR,
+};
+
 struct SearchedMove {
     Move move;
-    bool didLMR;
-    bool didZWS;
-    bool didPVS;
+    ScalingFactor scalingFactor;
     SearchedMove() {};
 
-    SearchedMove(Move m, bool dLMR, bool dZWS, bool dPVS) {
+    SearchedMove(Move m, ScalingFactor scale) {
         move = m;
-        didLMR = dLMR;
-        didZWS = dZWS;
-        didPVS = dPVS;
+        scalingFactor = scale;
     };
+
+    [[nodiscard]] int bonusScale() const {
+        return static_cast<int>(scalingFactor);
+    }
+
+    [[nodiscard]] int malusScale() const {
+        return 4 - static_cast<int>(scalingFactor);
+    }
 };
 
 struct SearchedMoveList {

--- a/src/history.h
+++ b/src/history.h
@@ -11,29 +11,32 @@ struct SearchData;
 struct SearchStack;
 struct MoveList;
 
-enum ScalingFactor {
-     None,
-     didPVS,
-     didZWS,
-     didLMR,
+enum SearchStage {
+    didNone,
+    didLMR,
+    didZWS,
+    didPVS,
+    Invalid
 };
 
 struct SearchedMove {
     Move move;
-    ScalingFactor scalingFactor;
+    SearchStage earliestSearchStage;
+    SearchStage latestSearchStage;
     SearchedMove() {};
 
-    SearchedMove(Move m, ScalingFactor scale) {
+    SearchedMove(Move m, SearchStage ESS, SearchStage LSS) {
         move = m;
-        scalingFactor = scale;
+        earliestSearchStage = ESS;
+        latestSearchStage = LSS;
     };
 
     [[nodiscard]] int bonusScale() const {
-        return static_cast<int>(scalingFactor);
+        return 4 - static_cast<int>(earliestSearchStage);
     }
 
     [[nodiscard]] int malusScale() const {
-        return 4 - static_cast<int>(scalingFactor);
+        return latestSearchStage;
     }
 };
 

--- a/src/history.h
+++ b/src/history.h
@@ -11,30 +11,19 @@ struct SearchData;
 struct SearchStack;
 struct MoveList;
 
-enum ScalingFactor {
-     None,
-     didPVS,
-     didZWS,
-     didLMR,
-};
-
 struct SearchedMove {
     Move move;
-    ScalingFactor scalingFactor;
+    bool didLMR;
+    bool didZWS;
+    bool didPVS;
     SearchedMove() {};
 
-    SearchedMove(Move m, ScalingFactor scale) {
+    SearchedMove(Move m, bool dLMR, bool dZWS, bool dPVS) {
         move = m;
-        scalingFactor = scale;
+        didLMR = dLMR;
+        didZWS = dZWS;
+        didPVS = dPVS;
     };
-
-    [[nodiscard]] int bonusScale() const {
-        return static_cast<int>(scalingFactor);
-    }
-
-    [[nodiscard]] int malusScale() const {
-        return 4 - static_cast<int>(scalingFactor);
-    }
 };
 
 struct SearchedMoveList {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -588,7 +588,8 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
         // we adjust the search depth based on potential extensions
         int newDepth = depth - 1 + extension;
-        ScalingFactor scalingFactor = None;
+        SearchStage earliestSearchStage = Invalid;
+        SearchStage latestSearchStage   = didNone;
 
         // Speculative prefetch of the TT entry
         TTPrefetch(keyAfter(pos, move));
@@ -632,7 +633,8 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
             // Carry out the reduced depth, zero window search
             score = -Negamax<false>(-alpha - 1, -alpha, reducedDepth, true, td, ss + 1);
-            scalingFactor = didLMR;
+            earliestSearchStage = std::min(earliestSearchStage, didLMR);
+            latestSearchStage   = std::max(latestSearchStage, didLMR);
 
             // If the reduced depth search fails high, do a full depth search (but still on zero window).
             if (score > alpha && newDepth > reducedDepth) {
@@ -642,7 +644,8 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
                 newDepth += doDeeperSearch - doShallowerSearch;
                 if (newDepth > reducedDepth) {
                     score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-                    scalingFactor = didZWS;
+                    earliestSearchStage = std::min(earliestSearchStage, didZWS);
+                    latestSearchStage   = std::max(latestSearchStage, didZWS);
                 }
             }
         }
@@ -653,18 +656,20 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
         // This zero window search will either confirm or deny our prediction, as the score cannot be exact (no integer lies in (-alpha - 1, -alpha))
         else if (!pvNode || totalMoves > 1) {
             score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-            scalingFactor = didZWS;
+            earliestSearchStage = std::min(earliestSearchStage, didZWS);
+            latestSearchStage   = std::max(latestSearchStage, didZWS);
         }
 
         // If this is our first move, we search with a full window.
         // Otherwise, if our zero window search fails low, this is a potential alpha raise and so we search the move fully.
         if (pvNode && (totalMoves == 1 || score > alpha)) {
             score = -Negamax<true>(-beta, -alpha, newDepth, false, td, ss + 1);
-            scalingFactor = didPVS;
+            earliestSearchStage = std::min(earliestSearchStage, didPVS);
+            latestSearchStage   = std::max(latestSearchStage, didPVS);
         }
 
         // Add the move to the corresponding list, along with the data on its search
-        SearchedMove moveData(move, scalingFactor);
+        SearchedMove moveData(move, earliestSearchStage, latestSearchStage);
         if (isQuiet) quietMoves.add(moveData);
         else tacticalMoves.add(moveData);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -588,7 +588,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
         // we adjust the search depth based on potential extensions
         int newDepth = depth - 1 + extension;
-        bool didLMR = false, didZWS = false, didPVS = false;
+        ScalingFactor scalingFactor = None;
 
         // Speculative prefetch of the TT entry
         TTPrefetch(keyAfter(pos, move));
@@ -632,7 +632,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
             // Carry out the reduced depth, zero window search
             score = -Negamax<false>(-alpha - 1, -alpha, reducedDepth, true, td, ss + 1);
-            didLMR = true;
+            scalingFactor = didLMR;
 
             // If the reduced depth search fails high, do a full depth search (but still on zero window).
             if (score > alpha && newDepth > reducedDepth) {
@@ -642,7 +642,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
                 newDepth += doDeeperSearch - doShallowerSearch;
                 if (newDepth > reducedDepth) {
                     score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-                    didZWS = true;
+                    scalingFactor = didZWS;
                 }
             }
         }
@@ -653,18 +653,18 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
         // This zero window search will either confirm or deny our prediction, as the score cannot be exact (no integer lies in (-alpha - 1, -alpha))
         else if (!pvNode || totalMoves > 1) {
             score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-            didZWS = true;
+            scalingFactor = didZWS;
         }
 
         // If this is our first move, we search with a full window.
         // Otherwise, if our zero window search fails low, this is a potential alpha raise and so we search the move fully.
         if (pvNode && (totalMoves == 1 || score > alpha)) {
             score = -Negamax<true>(-beta, -alpha, newDepth, false, td, ss + 1);
-            didPVS = true;
+            scalingFactor = didPVS;
         }
 
         // Add the move to the corresponding list, along with the data on its search
-        SearchedMove moveData(move, didLMR, didZWS, didPVS);
+        SearchedMove moveData(move, scalingFactor);
         if (isQuiet) quietMoves.add(moveData);
         else tacticalMoves.add(moveData);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -588,7 +588,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
         // we adjust the search depth based on potential extensions
         int newDepth = depth - 1 + extension;
-        ScalingFactor scalingFactor = None;
+        bool didLMR = false, didZWS = false, didPVS = false;
 
         // Speculative prefetch of the TT entry
         TTPrefetch(keyAfter(pos, move));
@@ -632,7 +632,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
 
             // Carry out the reduced depth, zero window search
             score = -Negamax<false>(-alpha - 1, -alpha, reducedDepth, true, td, ss + 1);
-            scalingFactor = didLMR;
+            didLMR = true;
 
             // If the reduced depth search fails high, do a full depth search (but still on zero window).
             if (score > alpha && newDepth > reducedDepth) {
@@ -642,7 +642,7 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
                 newDepth += doDeeperSearch - doShallowerSearch;
                 if (newDepth > reducedDepth) {
                     score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-                    scalingFactor = didZWS;
+                    didZWS = true;
                 }
             }
         }
@@ -653,18 +653,18 @@ int Negamax(int alpha, int beta, int depth, bool predictedCutNode, ThreadData* t
         // This zero window search will either confirm or deny our prediction, as the score cannot be exact (no integer lies in (-alpha - 1, -alpha))
         else if (!pvNode || totalMoves > 1) {
             score = -Negamax<false>(-alpha - 1, -alpha, newDepth, !predictedCutNode, td, ss + 1);
-            scalingFactor = didZWS;
+            didZWS = true;
         }
 
         // If this is our first move, we search with a full window.
         // Otherwise, if our zero window search fails low, this is a potential alpha raise and so we search the move fully.
         if (pvNode && (totalMoves == 1 || score > alpha)) {
             score = -Negamax<true>(-beta, -alpha, newDepth, false, td, ss + 1);
-            scalingFactor = didPVS;
+            didPVS = true;
         }
 
         // Add the move to the corresponding list, along with the data on its search
-        SearchedMove moveData(move, scalingFactor);
+        SearchedMove moveData(move, didLMR, didZWS, didPVS);
         if (isQuiet) quietMoves.add(moveData);
         else tacticalMoves.add(moveData);
 


### PR DESCRIPTION
Elo   | 1.52 +- 2.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 18244 W: 4579 L: 4499 D: 9166
Penta | [91, 2189, 4495, 2243, 104]
https://chess.swehosting.se/test/8312/

Bench 8217319