### PR TITLE
Adjust SEE tactical ordering threshold based on move history

### DIFF
--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -97,7 +97,7 @@ Move NextMove(Movepicker* mp, const bool skip) {
 
             assert(isTactical(move));
 
-            const int seeThreshold = -score / 32 + 236;
+            const int seeThreshold = -score * seeOrderScoreMult() / 1024 + seeOrderBase();
             if (!SEE(mp->pos, move, seeThreshold)) {
                 AddMove(move, score, &mp->badCaptureList);
                 continue;

--- a/src/movepicker.cpp
+++ b/src/movepicker.cpp
@@ -97,7 +97,8 @@ Move NextMove(Movepicker* mp, const bool skip) {
 
             assert(isTactical(move));
 
-            if (!SEE(mp->pos, move, -108)) {
+            const int seeThreshold = -score / 32 + 236;
+            if (!SEE(mp->pos, move, seeThreshold)) {
                 AddMove(move, score, &mp->badCaptureList);
                 continue;
             }

--- a/src/tune.h
+++ b/src/tune.h
@@ -101,6 +101,9 @@ TUNE_PARAM(nmpRedIirCoeff, 1024, 341, 1706, 68.0, 0.002)
 TUNE_PARAM(nmpRedEvalDiffMax, 896, 384, 1280, 54.0, 0.002)
 TUNE_PARAM(nmpRedEvalDiffDiv, 256, 128, 512, 20.0, 0.002)
 
+TUNE_PARAM(seeOrderScoreMult, 32, 16, 64, 2.4, 0.002)
+TUNE_PARAM(seeOrderBase, 236, 118, 472, 17.7, 0.002)
+
 TUNE_PARAM(quietPruningBase, 1690, 0, 2535, 128.0, 0.002)
 TUNE_PARAM(quietPruningMult, 366, 244, 549, 32.0, 0.002)
 


### PR DESCRIPTION
Elo   | 3.42 +- 2.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23890 W: 5938 L: 5703 D: 12249
Penta | [107, 2854, 5815, 3035, 134]
https://chess.swehosting.se/test/8605/

Bench 9822076